### PR TITLE
Improve  database.js -> get_last_txs

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -356,7 +356,7 @@ module.exports = {
   },
   
   get_last_txs: function(count, min, cb) {
-    Tx.find({'total': {$gt: min}}).sort({timestamp: 'desc'}).limit(count).exec(function(err, txs){
+    Tx.find({'total': {$gt: min}}).sort({_id: 'desc'}).limit(count).exec(function(err, txs){
       if (err) {
         return cb(err);
       } else {


### PR DESCRIPTION
get_last_txs seems to be very  slow on large indexes  , takes up 7s + or  times out  
i suggest to change  
```javascript
sort({timestamp: 'desc'}) - > sort({_id: 'desc'}) 
```
request time reduced to 300ms + 