### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "debug": "~0.7.4",
     "jade": "~1.3.0",
     "bitcoin-node-api": "0.1.0",
-    "request": "2.36.0",
+    "request": "2.74.0",
     "jsonminify": "0.2.3",
     "mongodb": "2.0.45",
     "mongoose": "4.1.10",


### PR DESCRIPTION
explorer currently has a 33 vulnerable dependency paths, introducing 15 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency and [ReDOS vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/iquidus/explorer) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.

You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade others dependencies as well.

Stay Secure,
The Snyk Team