### PR TITLE
Fix HTMLCOIN syncronization vault types

### DIFF
--- a/lib/explorer.js
+++ b/lib/explorer.js
@@ -284,7 +284,7 @@ module.exports = {
     module.exports.syncLoop(vout.length, function (loop) {
       var i = loop.iteration();
       // make sure vout has an address
-      if (vout[i].scriptPubKey.type != 'nonstandard' && vout[i].scriptPubKey.type != 'nulldata') { 
+      if (vout[i].scriptPubKey.type != 'nonstandard' && vout[i].scriptPubKey.type != 'nulldata' && vout[i].scriptPubKey.type != 'create' && vout[i].scriptPubKey.type != 'call') { 
         // check if vout address is unique, if so add it array, if not add its amount to existing index
         //console.log('vout:' + i + ':' + txid);
         module.exports.is_unique(arr_vout, vout[i].scriptPubKey.addresses[0], function(unique, index) {


### PR DESCRIPTION
Fixed missing vault types that unables iquidus sync block 6679 and some others

This issue happens everytime HTMLCOIN sync get into this block (and another forward but i didn't remember exactly wich one)

I don't know if it affects another coin or not, only tried syncing HTMLCOIN.