### PR TITLE
make /network display ipv6 properly

### DIFF
--- a/scripts/peers.js
+++ b/scripts/peers.js
@@ -26,7 +26,7 @@ mongoose.connect(dbString, function(err) {
     request({uri: 'http://127.0.0.1:' + settings.port + '/api/getpeerinfo', json: true}, function (error, response, body) {
       lib.syncLoop(body.length, function (loop) {
         var i = loop.iteration();
-        var address = body[i].addr.split(':')[0];
+        var address = body[i].addr.substring(0,body[i].addr.lastIndexOf(":"));
         db.find_peer(address, function(peer) {
           if (peer) {
             // peer already exists


### PR DESCRIPTION
`body[i].addr.split(':')[0];` isn't working on ipv6