### PR TITLE
Update_richlist: Fix memory overflow when indexing addresses with 1000s of TXs

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -319,7 +319,7 @@ module.exports = {
   //property: 'received' or 'balance'
   update_richlist: function(list, cb){
     if(list == 'received') {
-      Address.find({}).sort({received: 'desc'}).limit(100).exec(function(err, addresses){
+      Address.find({}, 'a_id balance received').sort({received: 'desc'}).limit(100).exec(function(err, addresses){
         Richlist.update({coin: settings.coin}, {
           received: addresses,
         }, function() {
@@ -327,7 +327,7 @@ module.exports = {
         });
       });
     } else { //balance
-      Address.find({}).sort({balance: 'desc'}).limit(100).exec(function(err, addresses){
+      Address.find({}, 'a_id balance received').sort({balance: 'desc'}).limit(100).exec(function(err, addresses){
         Richlist.update({coin: settings.coin}, {
           balance: addresses,
         }, function() {
@@ -451,6 +451,17 @@ module.exports = {
         console.log("initial richlist entry created for %s", coin);
         //console.log(newRichlist);
         return cb();
+      }
+    });
+  },
+
+  // drops richlist data for given coin
+  delete_richlist: function(coin, cb) {
+    Richlist.findOneAndRemove({coin: coin}, function(err, exists) {
+      if(exists) {
+        return cb(true);
+      } else {
+        return cb(false);
       }
     });
   },

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -1,9 +1,9 @@
 var mongoose = require('mongoose')
   , db = require('../lib/database')
-  , Tx = require('../models/tx')  
-  , Address = require('../models/address')  
-  , Richlist = require('../models/richlist')  
-  , Stats = require('../models/stats')  
+  , Tx = require('../models/tx')
+  , Address = require('../models/address')
+  , Richlist = require('../models/richlist')
+  , Stats = require('../models/stats')
   , settings = require('../lib/settings')
   , fs = require('fs');
 
@@ -47,6 +47,9 @@ if (process.argv[2] == 'index') {
       break;
     case 'reindex':
       mode = 'reindex';
+      break;
+    case 'reindex-rich':
+      mode = 'reindex-rich';
       break;
     default:
       usage();
@@ -152,10 +155,12 @@ is_locked(function (exists) {
                         }, function(err3) { 
                           Stats.update({coin: settings.coin}, { 
                             last: 0,
+                            count: 0,
+                            supply: 0,
                           }, function() {
                             console.log('index cleared (reindex)');
                           }); 
-                          db.update_tx_db(settings.coin, 1, stats.count, settings.update_timeout, function(){
+                          db.update_tx_db(settings.coin, 1, stats.count, settings.check_timeout, function(){
                             db.update_richlist('received', function(){
                               db.update_richlist('balance', function(){
                                 db.get_stats(settings.coin, function(nstats){
@@ -167,7 +172,7 @@ is_locked(function (exists) {
                           });
                         });
                       });
-                    });              
+                    });
                   } else if (mode == 'check') {
                     db.update_tx_db(settings.coin, 1, stats.count, settings.check_timeout, function(){
                       db.get_stats(settings.coin, function(nstats){
@@ -185,6 +190,34 @@ is_locked(function (exists) {
                           });
                         });
                       });
+                    });
+                  } else if (mode == 'reindex-rich') {
+                    console.log('update started');
+                    db.update_tx_db(settings.coin, stats.last, stats.count, settings.check_timeout, function(){
+                      console.log('update finished');
+                      db.check_richlist(settings.coin, function(exists){
+                        if (exists == true) {
+                          console.log('richlist entry found, deleting now..');
+                      	}
+                        db.delete_richlist(settings.coin, function(deleted) {
+                          if (deleted == true) {
+                            console.log('richlist entry deleted');
+                          }
+                          db.create_richlist(settings.coin, function() {
+                            console.log('richlist created.');
+                            db.update_richlist('received', function(){
+                              console.log('richlist updated received.');
+                              db.update_richlist('balance', function(){
+                                console.log('richlist updated balance.');
+                                db.get_stats(settings.coin, function(nstats){
+                                  console.log('update complete (block: %s)', nstats.last);
+                                  exit();
+                                });
+                              });
+                            });
+                          });
+                        });
+                      }); 
                     });
                   }
                 });


### PR DESCRIPTION
Richlist doesn't need to duplicate the TX list for every address indexed.

Also includes a function to delete entire richlist