### PR TITLE
Add `last_txs` to `getaddress` API

### DIFF
--- a/lib/database.js
+++ b/lib/database.js
@@ -417,7 +417,7 @@ module.exports = {
               } else {
                 var txs = [];
                 var count = address_tx.length;
-                var running_balance = balance_sum[0].balance;
+                var running_balance = balance_sum.length > 0 ? balance_sum[0].balance : 0;
 
                 var txs = [];
 


### PR DESCRIPTION
Moving from 1.6.2 to 1.7.X we (or me...) dropped the `last_txs` array from the `getaddress` API call.

This brings it back without any indexing changes.

Replicates exactly as it was before, even "addresses" when it should say "hash" :)

Fixes #392