### PR TITLE
1.6.1 -> 1.7.X - Settings.wallet: convert old `user` & `pass` strings

### DIFF
--- a/lib/settings.js
+++ b/lib/settings.js
@@ -181,6 +181,19 @@ exports.reloadSettings = function reloadSettings() {
     //we know this setting, so we overwrite it
     if(exports[i] !== undefined)
     {
+      // 1.6.2 -> 1.7.X we switched to a new coin RPC with different auth methods
+      // This check uses old .user and .pass config strings if they exist, and .username, .password don't.
+      if (i == 'wallet')
+      {
+        if (!settings.wallet.hasOwnProperty('username') && settings.wallet.hasOwnProperty('user'))
+        {
+          settings.wallet.username = settings.wallet.user;
+        }
+        if (!settings.wallet.hasOwnProperty('password') && settings.wallet.hasOwnProperty('pass'))
+        {
+          settings.wallet.password = settings.wallet.pass;
+        }
+      }
       exports[i] = settings[i];
     }
     //this setting is unkown, output a warning and throw it away

--- a/lib/settings.js
+++ b/lib/settings.js
@@ -132,7 +132,7 @@ exports.block_parallel_tasks = 1;
 exports.genesis_tx = "65f705d2f385dc85763a317b3ec000063003d6b039546af5d8195a5ec27ae410";
 exports.genesis_block = "b2926a56ca64e0cd2430347e383f63ad7092f406088b9b86d6d68c2a34baef51";
 
-exports.use_rpc = false;
+exports.use_rpc = true;
 exports.heavy = false;
 exports.lock_during_index = false;
 exports.txcount = 100;

--- a/settings.json.template
+++ b/settings.json.template
@@ -49,7 +49,7 @@
   "block_parallel_tasks": 1,
 
   // wallet settings
-  "use_rpc": false,
+  "use_rpc": true,
 
   "wallet": {
     "host": "localhost",


### PR DESCRIPTION
1.7.x introduced a new coin RPC with breaking changes to the settings. This was noted in the UPGRADE steps but it's not always seen by others. Fix here to convert old strings in the config for the new RPC

Also defaulting settings.use_rpc to true since we're going to retire the old code.