### PR TITLE
Fix node 14+ error ERR_INVALID_ARG_TYPE

### DIFF
--- a/bin/cluster
+++ b/bin/cluster
@@ -2,7 +2,7 @@ var cluster = require('cluster');
 var fs = require('fs');
 
 if (cluster.isMaster) {
-  fs.writeFile('./tmp/cluster.pid', process.pid, function (err) {
+  fs.writeFile('./tmp/cluster.pid', process.pid.toString(), function (err) {
     if (err) {
       console.log('Error: unable to create cluster.pid');
       process.exit(1);

--- a/lib/database.js
+++ b/lib/database.js
@@ -174,7 +174,7 @@ function get_market_data(market, cb) {
 function create_lock(lockfile, cb) {
   if (settings.lock_during_index == true) {
     var fname = './tmp/' + lockfile + '.pid';
-    fs.appendFile(fname, process.pid, function (err) {
+    fs.appendFile(fname, process.pid.toString(), function (err) {
       if (err) {
         console.log("Error: unable to create %s", fname);
         process.exit(1);

--- a/scripts/sync.js
+++ b/scripts/sync.js
@@ -65,7 +65,7 @@ if (process.argv[2] == 'index') {
 function create_lock(cb) {
   if ( database == 'index' ) {
     var fname = './tmp/' + database + '.pid';
-    fs.appendFile(fname, process.pid, function (err) {
+    fs.appendFile(fname, process.pid.toString(), function (err) {
       if (err) {
         console.log("Error: unable to create %s", fname);
         process.exit(1);


### PR DESCRIPTION
Fixes issues between node v14 and the iquidus explorer. Without this fix, you cannot even start the explorer as it crashes immidiately with the newest version of node.